### PR TITLE
add defaults feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,9 @@
 use serde::Serialize;
 use serde_json::Value as JsonValue;
-use tauri::{AppHandle, Event, Invoke, Manager, Runtime, State, Window, api::file::read_binary, command, plugin::Plugin};
+use tauri::{
+    api::file::read_binary, command, plugin::Plugin, AppHandle, Event, Invoke, Manager, Runtime,
+    State, Window,
+};
 
 use std::{
     collections::HashMap,
@@ -49,11 +52,11 @@ impl StoreFile {
         let store_path = app_dir.join(&self.path);
 
         let state = read_binary(&store_path)
-        .and_then(|state| bincode::deserialize::<String>(&state).map_err(Into::into))
-        .and_then(|state| serde_json::from_str(&state).map_err(Into::into));
+            .and_then(|state| bincode::deserialize::<String>(&state).map_err(Into::into))
+            .and_then(|state| serde_json::from_str(&state).map_err(Into::into));
 
         if let Ok(state) = state {
-                self.cache = state;
+            self.cache = state;
         }
         self
     }
@@ -242,7 +245,7 @@ impl<R: Runtime> Plugin<R> for Store<R> {
                 let path = PathBuf::from_str(key).expect("expected key to be valid file path");
                 let defaults = serde_json::from_value::<HashMap<String, JsonValue>>(value.clone())
                     .expect("failed to parse defaults");
-                
+
                 let mut store = StoreFile::with_defaults(path.clone(), defaults);
                 store.load(app);
 

--- a/webview-src/index.ts
+++ b/webview-src/index.ts
@@ -53,6 +53,7 @@ export default class Store {
       path: this.path
     })
   }
+  
   onKeyChange<T>(key: string, cb: (value: T | null) => void) {
     appWindow.listen<ChangePayload<T>>('store://change', event => {
       if (event.payload.path === this.path && event.payload.key === key) {

--- a/webview-src/index.ts
+++ b/webview-src/index.ts
@@ -48,6 +48,11 @@ export default class Store {
     })
   }
 
+  reset(): Promise<void> {
+    return invoke('plugin:store|reset', {
+      path: this.path
+    })
+  }
   onKeyChange<T>(key: string, cb: (value: T | null) => void) {
     appWindow.listen<ChangePayload<T>>('store://change', event => {
       if (event.payload.path === this.path && event.payload.key === key) {


### PR DESCRIPTION
This PR adds a default feature similar to [electron-store](https://github.com/sindresorhus/electron-store#defaults). Stores can be "pre-configured" through the `defaults` field in the plugins section of `tauri.conf.json`.

```json
    ],
    "security": {
      "csp": "default-src blob: data: filesystem: ws: http: https: 'unsafe-eval' 'unsafe-inline'"
    }
  },
  "plugins": {
    "store": {
      "defaults": {
        "foo": {
          "bar": true
        }
      }
    }
  }
}
```
the above snippet pre-configures the `foo` store with the KV pair `("bar", true)`.


This PR also exposes a method on the `Store` class called `reset` that can be used to reset a given store to their default values if any are given. If no defaults are given it clears the store.

Internally this creates `new`, `with_defaults` and `load` methods on the `StoreFile` struct with the latter being responsible for loading the state from disk.