### PR TITLE
add convenience methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,33 +148,6 @@ async fn clear<R: Runtime>(
     })
 }
 
-#[command]
-async fn reset<R: Runtime>(
-    app: AppHandle<R>,
-    window: Window<R>,
-    stores: State<'_, StoreCollection>,
-    path: PathBuf,
-) -> Result<(), String> {
-    with_store(&app, stores, path.clone(), |store| {
-        if let Some(defaults) = &store.defaults {
-            for (key, value) in &store.cache {
-                if defaults.get(key) != Some(value) {
-                    let _ = window.emit(
-                        "store://change",
-                        ChangePayload {
-                            path: path.clone(),
-                            key: key.clone(),
-                            value: defaults.get(key).cloned().unwrap_or(JsonValue::Null),
-                        },
-                    );
-                }
-            }
-            store.cache = defaults.clone();
-        }
-        Ok(())
-    })
-}
-
 #[tauri::command]
 async fn keys<R: Runtime>(
     app: AppHandle<R>,
@@ -226,7 +199,7 @@ impl<R: Runtime> Default for Store<R> {
     fn default() -> Self {
         Self {
             invoke_handler: Box::new(tauri::generate_handler![
-                set, get, has, delete, clear, reset, keys, values, length
+                set, get, has, delete, clear, keys, values, length
             ]),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use std::{
     fs::{create_dir_all, File},
     io::Write,
     path::PathBuf,
-    str::FromStr,
     sync::Mutex,
 };
 
@@ -199,7 +198,7 @@ impl<R: Runtime> Default for Store<R> {
     fn default() -> Self {
         Self {
             invoke_handler: Box::new(tauri::generate_handler![
-                set, get, has, delete, clear, keys, values, length
+                set, get, has, delete, clear, keys, values, length, entries
             ]),
         }
     }

--- a/webview-src/index.ts
+++ b/webview-src/index.ts
@@ -48,6 +48,36 @@ export default class Store {
     })
   }
 
+  reset(): Promise<void> {
+    return invoke('plugin:store|reset', {
+      path: this.path
+    })
+  }
+
+  keys(): Promise<string[]> {
+    return invoke('plugin:store|keys', {
+      path: this.path
+    })
+  }
+  
+  values(): Promise<string[]> {
+    return invoke('plugin:store|values', {
+      path: this.path
+    })
+  }
+
+  entries<T>(): Promise<[key: string, value: T][]> {
+    return invoke('plugin:store|entries', {
+      path: this.path
+    })
+  }
+
+  length(): Promise<string[]> {
+    return invoke('plugin:store|length', {
+      path: this.path
+    })
+  }
+
   onKeyChange<T>(key: string, cb: (value: T | null) => void) {
     appWindow.listen<ChangePayload<T>>('store://change', event => {
       if (event.payload.path === this.path && event.payload.key === key) {


### PR DESCRIPTION
This PR provides a couple convenience methods on the `Store` class:
- **`keys`** gets the list of all keys in the store
- **`values`** gets the list of all the values in the store
- **`entries`** gets a list of key-value tuples in the store
- **`length`** gets the number of entries in the store