### PR TITLE
Freeze `StoreCollection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ tag = "v0.1.0"
 
 Use in `src-tauri/src/main.rs`:
 ```rust
-use tauri_plugin_store::StorePlugin;
+use tauri_plugin_store::PluginBuilder;
 
 fn main() {
     tauri::Builder::default()
-        .plugin(StorePlugin::default())
+        .plugin(PluginBuilder::default())
         .build()
         .run();
 }

--- a/examples/svelte-app/src-tauri/src/main.rs
+++ b/examples/svelte-app/src-tauri/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
   tauri::Builder::default()
     .plugin(
       PluginBuilder::default()
-        .stores(vec![settings])
+        .stores([settings])
         .freeze()
         .build(),
     )

--- a/examples/svelte-app/src-tauri/src/main.rs
+++ b/examples/svelte-app/src-tauri/src/main.rs
@@ -3,7 +3,7 @@
   windows_subsystem = "windows"
 )]
 
-use tauri_plugin_store::{StoreBuilder, StorePlugin};
+use tauri_plugin_store::{StoreBuilder, PluginBuilder};
 
 fn main() {
   let settings = StoreBuilder::new(".settings".parse().unwrap())
@@ -11,7 +11,12 @@ fn main() {
     .build();
 
   tauri::Builder::default()
-    .plugin(StorePlugin::with_stores(vec![settings]))
+    .plugin(
+      PluginBuilder::default()
+        .stores(vec![settings])
+        .freeze()
+        .build(),
+    )
     .run(tauri::generate_context!())
     .expect("failed to run app");
 }

--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -20,6 +20,11 @@
 			.then(_updateResponse)
 			.catch(_updateResponse)
 	}
+
+	function set_broken() {
+		const brokenStore = new Store('broken')
+		brokenStore.set('foo', 'bar')
+	}
 </script>
 
 <style>
@@ -27,7 +32,9 @@
 		background: #fff;
 	}
 </style>
-
+<div>
+	<button on:click="{set_broken}">Broken</button>
+</div>
 <div>
 	<input placeholder="The value to store" bind:value={record}>
 	<button on:click="{set}">Set</button>

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
+use std::path::PathBuf;
+
 use serde::{Serialize, Serializer};
 
 /// The error types.
@@ -17,6 +19,9 @@ pub enum Error {
   /// IO error.
   #[error(transparent)]
   Io(#[from] std::io::Error),
+  /// Store not found
+  #[error("Store \"{0}\" not found")]
+  NotFound(PathBuf),
 }
 
 impl Serialize for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,11 +243,41 @@ pub struct PluginBuilder {
 }
 
 impl PluginBuilder {
+  /// Registers a store with the plugin.
+  /// 
+  /// # Examples
+  /// 
+  /// ```
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
+  ///
+  /// let store = StoreBuilder::new("store.bin".parse()?).build();
+  ///
+  /// let builder = PluginBuilder::default().store(store);
+  /// 
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn store(mut self, store: Store) -> Self {
     self.stores.insert(store.path.clone(), store);
     self
   }
 
+  /// Registers multiple stores with the plugin.
+  /// 
+  /// # Examples
+  /// 
+  /// ```
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
+  ///
+  /// let store = StoreBuilder::new("store.bin".parse()?).build();
+  ///
+  /// let builder = PluginBuilder::default().stores([store]);
+  /// 
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn stores<T: IntoIterator<Item = Store>>(mut self, stores: T) -> Self {
     self.stores = stores
       .into_iter()
@@ -256,11 +286,44 @@ impl PluginBuilder {
     self
   }
 
+  /// Freezes the collection.
+  /// 
+  /// This causes requests for plugins that haven't been registered to fail
+  ///
+  /// # Examples
+  ///  
+  /// ```
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
+  ///
+  /// let store = StoreBuilder::new("store.bin".parse()?).build();
+  ///
+  /// let builder = PluginBuilder::default().freeze();
+  /// 
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn freeze(mut self) -> Self {
     self.frozen = true;
     self
   }
 
+  /// Builds the plugin.
+  /// 
+  /// # Examples
+  /// 
+  /// ```
+  /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+  /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
+  /// use tauri::Wry;
+  /// 
+  /// let store = StoreBuilder::new("store.bin".parse()?).build();
+  ///
+  /// let plugin = PluginBuilder::default().build::<Wry>();
+  /// 
+  /// # Ok(())
+  /// # }
+  /// ```
   pub fn build<R: Runtime>(self) -> Plugin<R> {
     Plugin {
       invoke_handler: Box::new(tauri::generate_handler![

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::{collections::HashMap, path::PathBuf, sync::Mutex};
 pub use store::{Store, StoreBuilder};
-use tauri::{plugin::Plugin, AppHandle, Event, Invoke, Manager, Runtime, State, Window};
+use tauri::{plugin::Plugin as TauriPlugin, AppHandle, Event, Invoke, Manager, Runtime, State, Window};
 
 mod error;
 mod store;
@@ -260,7 +260,8 @@ impl<R: Runtime> StorePlugin<R> {
   }
 }
 
-impl<R: Runtime> Plugin<R> for StorePlugin<R> {
+pub struct Plugin<R: Runtime> {
+impl<R: Runtime> TauriPlugin<R> for Plugin<R> {
   fn name(&self) -> &'static str {
     "store"
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@ use serde::Serialize;
 use serde_json::Value as JsonValue;
 use std::{collections::HashMap, path::PathBuf, sync::Mutex};
 pub use store::{Store, StoreBuilder};
-use tauri::{plugin::Plugin as TauriPlugin, AppHandle, Event, Invoke, Manager, Runtime, State, Window};
+use tauri::{
+  plugin::Plugin as TauriPlugin, AppHandle, Event, Invoke, Manager, Runtime, State, Window,
+};
 
 mod error;
 mod store;
@@ -20,17 +22,23 @@ struct ChangePayload {
 }
 
 #[derive(Default)]
-struct StoreCollection(Mutex<HashMap<PathBuf, Store>>);
+struct StoreCollection {
+  stores: Mutex<HashMap<PathBuf, Store>>,
+  frozen: bool,
+}
 
 fn with_store<R: Runtime, T, F: FnOnce(&mut Store) -> Result<T, Error>>(
   app: &AppHandle<R>,
-  stores: State<'_, StoreCollection>,
+  collection: State<'_, StoreCollection>,
   path: PathBuf,
   f: F,
 ) -> Result<T, Error> {
-  let mut stores = stores.0.lock().expect("mutex poisoned");
+  let mut stores = collection.stores.lock().expect("mutex poisoned");
 
   if !stores.contains_key(&path) {
+    if collection.frozen {
+      return Err(Error::NotFound(path));
+    }
     let mut store = StoreBuilder::new(path.clone()).build();
     // ignore loading errors, just use the default
     let _ = store.load(app);
@@ -134,18 +142,18 @@ async fn clear<R: Runtime>(
 async fn reset<R: Runtime>(
   app: AppHandle<R>,
   window: Window<R>,
-  stores: State<'_, StoreCollection>,
+  collection: State<'_, StoreCollection>,
   path: PathBuf,
 ) -> Result<(), Error> {
-  let has_defaults = stores
-    .0
+  let has_defaults = collection
+    .stores
     .lock()
     .expect("mutex poisoned")
     .get(&path)
     .map(|store| store.defaults.is_some());
 
   if Some(true) == has_defaults {
-    with_store(&app, stores, path.clone(), |store| {
+    with_store(&app, collection, path.clone(), |store| {
       if let Some(defaults) = &store.defaults {
         for (key, value) in &store.cache {
           if defaults.get(key) != Some(value) {
@@ -164,7 +172,7 @@ async fn reset<R: Runtime>(
       Ok(())
     })
   } else {
-    clear(app, window, stores, path).await
+    clear(app, window, collection, path).await
   }
 }
 
@@ -228,39 +236,48 @@ async fn save<R: Runtime>(
   with_store(&app, stores, path, |store| store.save(&app))
 }
 
-pub struct StorePlugin<R: Runtime> {
-  invoke_handler: Box<dyn Fn(Invoke<R>) + Send + Sync>,
-  stores: Option<HashMap<PathBuf, Store>>,
+#[derive(Default)]
+pub struct PluginBuilder {
+  stores: HashMap<PathBuf, Store>,
+  frozen: bool,
 }
 
-impl<R: Runtime> Default for StorePlugin<R> {
-  fn default() -> Self {
-    Self {
-      invoke_handler: Box::new(tauri::generate_handler![
-        set, get, has, delete, clear, reset, keys, values, length, entries, load, save
-      ]),
-      stores: None,
-    }
+impl PluginBuilder {
+  pub fn store(mut self, store: Store) -> Self {
+    self.stores.insert(store.path.clone(), store);
+    self
   }
-}
 
-impl<R: Runtime> StorePlugin<R> {
-  pub fn with_stores<T: IntoIterator<Item = Store>>(stores: T) -> Self {
-    Self {
+  pub fn stores<T: IntoIterator<Item = Store>>(mut self, stores: T) -> Self {
+    self.stores = stores
+      .into_iter()
+      .map(|store| (store.path.clone(), store))
+      .collect();
+    self
+  }
+
+  pub fn freeze(mut self) -> Self {
+    self.frozen = true;
+    self
+  }
+
+  pub fn build<R: Runtime>(self) -> Plugin<R> {
+    Plugin {
       invoke_handler: Box::new(tauri::generate_handler![
         set, get, has, delete, clear, reset, keys, values, length, entries, load, save
       ]),
-      stores: Some(
-        stores
-          .into_iter()
-          .map(|store| (store.path.clone(), store))
-          .collect(),
-      ),
+      stores: self.stores,
+      frozen: self.frozen,
     }
   }
 }
 
 pub struct Plugin<R: Runtime> {
+  invoke_handler: Box<dyn Fn(Invoke<R>) + Send + Sync>,
+  stores: HashMap<PathBuf, Store>,
+  frozen: bool,
+}
+
 impl<R: Runtime> TauriPlugin<R> for Plugin<R> {
   fn name(&self) -> &'static str {
     "store"
@@ -271,17 +288,18 @@ impl<R: Runtime> TauriPlugin<R> for Plugin<R> {
   }
 
   fn initialize(&mut self, app: &AppHandle<R>, _: JsonValue) -> tauri::plugin::Result<()> {
-    app.manage(StoreCollection(Mutex::new(
-      self.stores.clone().unwrap_or_default(),
-    )));
+    app.manage(StoreCollection {
+      stores: Mutex::new(self.stores.clone()),
+      frozen: self.frozen,
+    });
     Ok(())
   }
 
   fn on_event(&mut self, app: &AppHandle<R>, event: &tauri::Event) {
     if let Event::Exit = event {
-      let stores = app.state::<StoreCollection>();
+      let collection = app.state::<StoreCollection>();
 
-      for store in stores.0.lock().expect("mutex poisoned").values() {
+      for store in collection.stores.lock().expect("mutex poisoned").values() {
         if let Err(err) = store.save(app) {
           eprintln!("failed to save store {:?} with error {:?}", store.path, err);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,9 +244,9 @@ pub struct PluginBuilder {
 
 impl PluginBuilder {
   /// Registers a store with the plugin.
-  /// 
+  ///
   /// # Examples
-  /// 
+  ///
   /// ```
   /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
   /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
@@ -254,7 +254,7 @@ impl PluginBuilder {
   /// let store = StoreBuilder::new("store.bin".parse()?).build();
   ///
   /// let builder = PluginBuilder::default().store(store);
-  /// 
+  ///
   /// # Ok(())
   /// # }
   /// ```
@@ -264,9 +264,9 @@ impl PluginBuilder {
   }
 
   /// Registers multiple stores with the plugin.
-  /// 
+  ///
   /// # Examples
-  /// 
+  ///
   /// ```
   /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
   /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
@@ -274,7 +274,7 @@ impl PluginBuilder {
   /// let store = StoreBuilder::new("store.bin".parse()?).build();
   ///
   /// let builder = PluginBuilder::default().stores([store]);
-  /// 
+  ///
   /// # Ok(())
   /// # }
   /// ```
@@ -287,7 +287,7 @@ impl PluginBuilder {
   }
 
   /// Freezes the collection.
-  /// 
+  ///
   /// This causes requests for plugins that haven't been registered to fail
   ///
   /// # Examples
@@ -299,7 +299,7 @@ impl PluginBuilder {
   /// let store = StoreBuilder::new("store.bin".parse()?).build();
   ///
   /// let builder = PluginBuilder::default().freeze();
-  /// 
+  ///
   /// # Ok(())
   /// # }
   /// ```
@@ -309,18 +309,18 @@ impl PluginBuilder {
   }
 
   /// Builds the plugin.
-  /// 
+  ///
   /// # Examples
-  /// 
+  ///
   /// ```
   /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
   /// use tauri_plugin_store::{StoreBuilder,PluginBuilder};
   /// use tauri::Wry;
-  /// 
+  ///
   /// let store = StoreBuilder::new("store.bin".parse()?).build();
   ///
   /// let plugin = PluginBuilder::default().build::<Wry>();
-  /// 
+  ///
   /// # Ok(())
   /// # }
   /// ```


### PR DESCRIPTION
Wanted to bring one last (for now) addition to this plugin:
Right now the JS code can create arbitrary stores and therefore store arbitrary files on disk.
This PR introduces a `PluginBuilder` that allows the `StoreCollection` to be frozen:
```rust
use tauri_plugin_store::{StoreBuilder, PluginBuilder};

fn main() {
  let settings = StoreBuilder::new(".settings".parse().unwrap()).build();

  tauri::Builder::default()
    .plugin(
      PluginBuilder::default()
        .stores([settings])
        .freeze() // This method freezes the collection
        .build(),
    )
    .run(tauri::generate_context!())
    .expect("failed to run app");
}
```
This way only stores declared in rust code can be accessed from JS.
```js
const works = new Store(".settings")
works.keys() // This works because the ".settings" store has been declared

const broken = new Store(".broken")
broken.keys() // This will reject with a NotFound error
```