### PR TITLE
Save store to app dir instead of working dir

### DIFF
--- a/.changes/fix-save-location.md
+++ b/.changes/fix-save-location.md
@@ -1,0 +1,5 @@
+---
+"tauri-plugin-store": minor
+---
+
+Make sure the stores are saved to the application directory instead of the working directory.

--- a/src/store.rs
+++ b/src/store.rs
@@ -193,7 +193,7 @@ impl Store {
     create_dir_all(store_path.parent().expect("invalid store path"))?;
 
     let bytes = (self.serialize)(&self.cache)?;
-    let mut f = File::create(&self.path)?;
+    let mut f = File::create(&store_path)?;
     f.write_all(&bytes)?;
 
     Ok(())


### PR DESCRIPTION
Hi! Was trying out this plugin a bit, and noticed it didn't save the store correctly, instead writing to the working directory. Looked into it a bit and it seems there was a small oversight in the saving code :)