### PR TITLE
fix: custom serde callbacks

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,14 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-License-Identifier: MIT
 
-use std::path::PathBuf;
-
 use serde::{Serialize, Serializer};
+use std::path::PathBuf;
 
 /// The error types.
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
+  #[error("Failed to serialize store. {0}")]
+  Serialize(Box<dyn std::error::Error>),
+  #[error("Failed to deserialize store. {0}")]
+  Deserialize(Box<dyn std::error::Error>),
   /// JSON error.
   #[error(transparent)]
   Json(#[from] serde_json::Error),


### PR DESCRIPTION
This fixes the double serialization problem and allows users to return any error type from serde callbacks.