### PR TITLE
serialize with serde_json instead of bincode, closes #64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,9 @@ exclude = ["/examples", "/webview-dist", "/webview-src", "node_modules"]
 license = "Apache-2.0 OR MIT"
 
 [dependencies]
-tauri = "1.0.0-rc.3"
+tauri = "1.0.0-rc.6"
 serde = "1.0"
 serde_json = "1.0"
-bincode = "1.3"
 thiserror = "1.0"
 
 [features]

--- a/examples/svelte-app/package.json
+++ b/examples/svelte-app/package.json
@@ -10,24 +10,24 @@
         "tauri": "tauri"
     },
     "devDependencies": {
-        "@rollup/plugin-commonjs": "^17.0.0",
-        "@rollup/plugin-node-resolve": "^11.0.0",
-        "@rollup/plugin-typescript": "^8.0.0",
-        "@tauri-apps/cli": "^1.0.0-rc.0",
-        "@tsconfig/svelte": "^2.0.0",
-        "rollup": "^2.3.4",
+        "@rollup/plugin-commonjs": "^17.1.0",
+        "@rollup/plugin-node-resolve": "^11.2.1",
+        "@rollup/plugin-typescript": "^8.3.1",
+        "@tauri-apps/cli": "^1.0.0-rc.8",
+        "@tsconfig/svelte": "^2.0.1",
+        "rollup": "^2.70.1",
         "rollup-plugin-css-only": "^3.1.0",
-        "rollup-plugin-livereload": "^2.0.0",
-        "rollup-plugin-svelte": "^7.0.0",
-        "rollup-plugin-terser": "^7.0.0",
-        "svelte": "^3.0.0",
-        "svelte-check": "^2.0.0",
-        "svelte-preprocess": "^4.0.0",
-        "tslib": "^2.0.0",
-        "typescript": "^4.0.0"
+        "rollup-plugin-livereload": "^2.0.5",
+        "rollup-plugin-svelte": "^7.1.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "svelte": "^3.46.6",
+        "svelte-check": "^2.4.6",
+        "svelte-preprocess": "^4.10.4",
+        "tslib": "^2.3.1",
+        "typescript": "^4.6.3"
     },
     "dependencies": {
-        "sirv-cli": "^2.0.0",
+        "sirv-cli": "^2.0.2",
         "tauri-plugin-store-api": "../../"
     }
 }

--- a/examples/svelte-app/src-tauri/Cargo.toml
+++ b/examples/svelte-app/src-tauri/Cargo.toml
@@ -10,12 +10,12 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = "1.0.0-rc.1"
+tauri-build = { version = "1.0.0-rc.5", features = [] }
 
 [dependencies]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.0.0-rc.1", features = ["api-all"] }
+tauri = { version = "1.0.0-rc.6", features = ["api-all"] }
 tauri-plugin-store = { path = "../../../" }
 
 [features]

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,9 +16,6 @@ pub enum Error {
   /// JSON error.
   #[error(transparent)]
   Json(#[from] serde_json::Error),
-  /// Bincode error.
-  #[error(transparent)]
-  Bincode(#[from] Box<bincode::ErrorKind>),
   /// IO error.
   #[error(transparent)]
   Io(#[from] std::io::Error),

--- a/src/store.rs
+++ b/src/store.rs
@@ -18,13 +18,13 @@ type DeserializeFn = fn(&[u8]) -> Result<HashMap<String, JsonValue>, Box<dyn std
 fn default_serialize(
   cache: &HashMap<String, JsonValue>,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
-  Ok(bincode::serialize(&cache)?)
+  Ok(serde_json::to_vec(&cache)?)
 }
 
 fn default_deserialize(
   bytes: &[u8],
 ) -> Result<HashMap<String, JsonValue>, Box<dyn std::error::Error>> {
-  bincode::deserialize(bytes).map_err(Into::into)
+  serde_json::from_slice(bytes).map_err(Into::into)
 }
 
 /// Builds a [`Store`]


### PR DESCRIPTION
As said in tauri-apps/plugins-workspace#227 the problem is that we use `serde_json::Value` which can't be ~~serialized~~ deserialized with bincode (doesn't work with bincode@v2 either (by design)).

string-like values were (depending on the editor) human readable with bincode anyway, so we're not losing much obfuscation. That said, we _could_ add something to change that, but that might be something for a different PR.