### PR TITLE
Added links to MIT and Apache licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ assert(val, { value: 5 });
 
 # License
 
-MIT / Apache-2.0
+[MIT](https://github.com/tauri-apps/tauri-plugin-store/blob/dev/LICENSE_MIT) / [Apache-2.0](https://github.com/tauri-apps/tauri-plugin-store/blob/dev/LICENSE_APACHE-2.0)

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ assert(val, { value: 5 });
 
 # License
 
-[MIT](https://github.com/tauri-apps/tauri-plugin-store/blob/dev/LICENSE_MIT) / [Apache-2.0](https://github.com/tauri-apps/tauri-plugin-store/blob/dev/LICENSE_APACHE-2.0)
+[MIT](/LICENSE_MIT) / [Apache-2.0](/LICENSE_APACHE-2.0)


### PR DESCRIPTION
Noticed that the licenses were not linked at the bottom of the README.md and fixed them.
<img width="173" alt="Screenshot 2022-05-09 at 11 30 15" src="https://user-images.githubusercontent.com/102547056/167392598-973ccc74-60c3-41fe-87b0-3c7d74b03790.png">

