### PR TITLE
Add install from branch step

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ npm install github:tauri-apps/tauri-plugin-store#488558717b77d8a2bcb37acfd2eca96
 yarn add github:tauri-apps/tauri-plugin-store#488558717b77d8a2bcb37acfd2eca9658aeadc8e
 ```
 
+`Install from a branch (dev)`
+
+```
+npm install https://github.com/tauri-apps/tauri-plugin-store\#dev
+# or
+yarn add https://github.com/tauri-apps/tauri-plugin-store\#dev
+```
+
 `package.json`
 
 ```json


### PR DESCRIPTION
It might be temporary but still might help someone who is not entirely sure how to install from branch.
Left other installation steps untouched as they might become correct once v1 goes live and plugin gets published