### PR TITLE
update readme with installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ For more details and usage see [the example app](examples/svelte-app). Please no
 ```yaml
 [dependencies.tauri-plugin-store]
 git = "https://github.com/tauri-apps/tauri-plugin-store"
-tag = "v0.1.0"
-#branch = "main"
+#tag = "v0.1.0"
+branch = "dev"
 ```
 
 Use in `src-tauri/src/main.rs`:


### PR DESCRIPTION
Update readme with installation instructions pointing at "dev" branch rather than non-existent "main" branch. Also commented out tag `v0.1.0` since it fails to find the listed tag.