### PR TITLE
fix: load state from disk and extend defaults

### DIFF
--- a/src/store.rs
+++ b/src/store.rs
@@ -179,7 +179,7 @@ impl Store {
 
     let bytes = read(&store_path)?;
 
-    self.cache = (self.deserialize)(&bytes).map_err(Error::Deserialize)?;
+    self.cache.extend((self.deserialize)(&bytes).map_err(Error::Deserialize)?);
 
     Ok(())
   }


### PR DESCRIPTION
The default state does not work when there is a file saved.
So loading the on-disk state and extending the defaults works.