### PR TITLE
remove typefest

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
         "@rollup/plugin-typescript": "8.3.3",
         "rollup": "2.75.7",
         "rollup-plugin-terser": "7.0.2",
-        "type-fest": "2.12.2",
         "typedoc": "0.22.15",
         "typescript": "4.7.4"
     },


### PR DESCRIPTION
This removes the `typefest` dep that we added as a workaround when `@tauri-apps/api` was missing this as a peer dependency