### PR TITLE
Correct storage folder documentation in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![devto](https://img.shields.io/badge/documentation-github.io-purple.svg)](https://tauri-apps.github.io/tauri-plugin-store)
 ![Test](https://github.com/tauri-apps/tauri-plugin-store/workflows/Test/badge.svg)
 
-This plugin provides an interface for storing unencrypted values on the application cache folder.
+This plugin provides an interface for storing unencrypted values on the application configuration files folder.
 
 ## Installation
 


### PR DESCRIPTION
Experimental results and source code reviews show that the stores managed by this plugin are saved under `app_dir()`, which [is defined to return a platform-specific directory for app-specific configuration files](https://docs.rs/tauri/1.1.1/tauri/struct.PathResolver.html#method.app_dir):

https://github.com/tauri-apps/tauri-plugin-store/blob/4326f75446b8b9e0cb9904c65f258b81e23e544e/src/store.rs#L187-L193

However, the `README.md` file currently states that files are stored "on the application cache folder". I find this wording confusing, because Tauri does not expose any APIs to return an app-specific cache directory (but [there is a function to return the user's cache directory](https://docs.rs/tauri/1.1.1/tauri/api/path/fn.cache_dir.html)), and the path returned by `app_dir` is clearly meant to store persistent store data, not transient cache information like `cache_dir`.

This PR replaces the described mention to the cache folder with the configuration files folder, so its meaning should be more precise and clear from the start.

Thank you!